### PR TITLE
Support showing only the time for same-day end-times

### DIFF
--- a/_events/sr2022/horsham-in-person-tech-day-april.md
+++ b/_events/sr2022/horsham-in-person-tech-day-april.md
@@ -1,6 +1,7 @@
 ---
 title: April In-Person Tech Day
 date: 2022-04-02 10:00:00 Europe/London
+end_date: 2022-04-02 15:00:00 Europe/London
 layout: event
 type: tech-day
 location: <a href="https://www.google.co.uk/maps/place/Metricell+Limited/@51.0722759,-0.3165972,17z/data=!3m1!4b1!4m5!3m4!1s0x4875ea527109425b:0xd6eab9172197b909!8m2!3d51.0722547!4d-0.3142888">Metricell, Horsham</a>

--- a/_includes/datetime.html
+++ b/_includes/datetime.html
@@ -30,6 +30,14 @@
     {{ include.event.date | date:include.datetime_format }}
   </time>
   {% if include.event.end_date %}
+    {% assign start_date = include.event.date | date:'%F' %}
+    {% assign end_date = include.event.end_date | date:'%F' %}
+    {% if start_date == end_date %}
+      {% assign end_date_format = include.time_only_format %}
+    {% else %}
+      {% assign end_date_format = include.datetime_format %}
+    {% endif %}
+
     &mdash;
     <time
       {{ cancelled }}
@@ -37,7 +45,7 @@
       datetime="{{ include.event.end_date | date_to_xmlschema }}"
       title="{{ include.event.end_date | date_to_rfc822 }}"
     >
-      {{ include.event.end_date | date:include.datetime_format }}
+      {{ include.event.end_date | date:end_date_format }}
     </time>
   {% endif %}
 {% endif %}

--- a/_includes/datetime.html
+++ b/_includes/datetime.html
@@ -34,6 +34,7 @@
     {% assign end_date = include.event.end_date | date:'%F' %}
     {% if start_date == end_date %}
       {% assign end_date_format = include.time_only_format %}
+      {% assign time_only = 'data-time-only' %}
     {% else %}
       {% assign end_date_format = include.datetime_format %}
     {% endif %}
@@ -41,6 +42,7 @@
     &mdash;
     <time
       {{ cancelled }}
+      {{ time_only }}
       class="time-span"
       datetime="{{ include.event.end_date | date_to_xmlschema }}"
       title="{{ include.event.end_date | date_to_rfc822 }}"

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -17,7 +17,7 @@ layout: page
             {# Changing the format here? Also change the event page and the localise_times function #}
             {% endcomment %}
             {% assign date_only_format = '%e %B %Y <small class="muted">(time <abbr title="To be confirmed">TBC</abbr>)</small>' %}
-            {% include datetime.html date_only_format=date_only_format datetime_format='%e %B %Y at %l%P' event=page %}
+            {% include datetime.html date_only_format=date_only_format datetime_format='%e %B %Y at %l%P' time_only_format = '%l%P' event=page %}
           </li>
           <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ page.location }}</li>
         </ul>

--- a/events.html
+++ b/events.html
@@ -33,7 +33,7 @@ permalink: /events/
               {% comment %}
               {# Changing the format here? Also change the event page and the localise_times function #}
               {% endcomment %}
-              {% include datetime.html date_only_format='%e %B %Y' datetime_format='%e %B %Y at %l%P' event=event %}
+              {% include datetime.html date_only_format='%e %B %Y' datetime_format='%e %B %Y at %l%P' time_only_format = '%l%P' event=event %}
             </div>
             <div class="column d-12-12 l-4-12">{{ event.location }}</div>
           </li>

--- a/js/localise-times.js
+++ b/js/localise-times.js
@@ -1,17 +1,25 @@
 function localise_times(site_timezone) {
-  let options = {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
+  let time_options = {
     hour: 'numeric',
     hour12: true,
     minute: 'numeric',
     dayPeriod: 'short',
     timeZoneName: 'short',
   };
+
+  let options = {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    ...time_options
+  };
   const date_formatter_with_minutes = Intl.DateTimeFormat(undefined, options);
   delete options.minute;
   const date_formatter_without_minutes = Intl.DateTimeFormat(undefined, options);
+
+  const time_formatter_with_minutes = Intl.DateTimeFormat(undefined, time_options);
+  delete time_options.minute;
+  const time_formatter_without_minutes = Intl.DateTimeFormat(undefined, time_options);
 
   if (date_formatter_with_minutes.resolvedOptions().timeZone == site_timezone) {
     return;
@@ -23,11 +31,13 @@ function localise_times(site_timezone) {
       return;
     }
 
+    const time_only = elem.hasAttribute('data-time-only');
+
     const date = new Date(datetime);
     const formatter =
       date.getMinutes() > 0
-        ? date_formatter_with_minutes
-        : date_formatter_without_minutes;
+        ? time_only ? time_formatter_with_minutes : date_formatter_with_minutes
+        : time_only ? time_formatter_without_minutes : date_formatter_without_minutes;
 
     let parts = formatter.formatToParts(date).map(({ type, value }) => {
       if (type == 'timeZoneName') {


### PR DESCRIPTION
This adds an example case and then implements the functionality - both Jekyll and in our localisation logic.

![image](https://user-images.githubusercontent.com/336212/163577104-23ab8537-f173-4ef9-ac64-32e4322264df.png)

![image](https://user-images.githubusercontent.com/336212/163577002-507cec7a-6354-49d6-b7be-044eb0f4cc14.png)
